### PR TITLE
Add ESP option to NPC behavior

### DIFF
--- a/Content.Server/NPC/NPCBlackboard.cs
+++ b/Content.Server/NPC/NPCBlackboard.cs
@@ -34,6 +34,7 @@ public sealed partial class NPCBlackboard : IEnumerable<KeyValuePair<string, obj
         {"RangedRange", 10f},
         {"RotateSpeed", float.MaxValue},
         {"VisionRadius", 10f},
+        {"ESP", false}, // CalderaSite - Gives NPCs wallhacks so they can chase players
     };
 
     /// <summary>
@@ -290,6 +291,11 @@ public sealed partial class NPCBlackboard : IEnumerable<KeyValuePair<string, obj
     public const string Owner = "Owner";
     public const string OwnerCoordinates = "OwnerCoordinates";
     public const string MovementTarget = "MovementTarget";
+
+    /// <summary>
+    /// CalderaSite - the NPC can see infinitely through obstacles.
+    /// </summary>
+    public const string ESP = "ESP";
 
     /// <summary>
     /// Can the NPC click open entities such as doors.

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -296,6 +296,10 @@ public sealed class NPCUtilitySystem : EntitySystem
             {
                 var radius = blackboard.GetValueOrDefault<float>(NPCBlackboard.VisionRadius, EntityManager);
 
+                // CalderaSite - All potential targets are in LOS if NPC has ESP
+                if (blackboard.GetValueOrDefault<bool>("ESP", EntityManager))
+                    return 1f;
+
                 return ExamineSystemShared.InRangeUnOccluded(owner, targetUid, radius + 0.5f, null) ? 1f : 0f;
             }
             case TargetInLOSOrCurrentCon:
@@ -312,6 +316,10 @@ public sealed class NPCUtilitySystem : EntitySystem
                 {
                     return 1f;
                 }
+
+                // CalderaSite - All potential targets are in LOS if NPC has ESP
+                if (blackboard.GetValueOrDefault<bool>("ESP", EntityManager))
+                    return 1f;
 
                 return ExamineSystemShared.InRangeUnOccluded(owner, targetUid, radius + bufferRange, null) ? 1f : 0f;
             }

--- a/Resources/Prototypes/Nuclear14/Mobs/NPCs/basemob.yml
+++ b/Resources/Prototypes/Nuclear14/Mobs/NPCs/basemob.yml
@@ -20,6 +20,8 @@
         true
       VisionRadius: !type:Single
         1000.0
+      IdleRange: !type:Single
+        10.0
   - type: WaveMob
     difficulty: 1
 


### PR DESCRIPTION
# Description

Hostile mobs have an ESP (extrasensory perception) option on the their blackboard now. 
It allows them to target their enemies through walls. NPCs with ESP will attack walls to reach their target.
This is achieved by modifying the NPCUtilitySystem. All potential targets are in line of sight if the NPC has ESP set to true.

---

# Changelog

:cl: Finket
- add: Added ESP option to NPCs
